### PR TITLE
Fix WFGM compatibility hook

### DIFF
--- a/src/main/java/nl/enjarai/showmeyourskin/compat/wildfire_gender/WildfireGenderMixinPlugin.java
+++ b/src/main/java/nl/enjarai/showmeyourskin/compat/wildfire_gender/WildfireGenderMixinPlugin.java
@@ -7,7 +7,6 @@ import java.util.Set;
 public class WildfireGenderMixinPlugin implements CompatMixinPlugin {
     @Override
     public Set<String> getRequiredMods() {
-        // This compat module is disabled for now since gender mod is not available for 1.20.4 yet.
-        return Set.of("wildfire_gender", "dont-use-right-now-alr-thx");
+        return Set.of("wildfire_gender");
     }
 }

--- a/src/main/java/nl/enjarai/showmeyourskin/compat/wildfire_gender/mixin/BreastPhysicsMixin.java
+++ b/src/main/java/nl/enjarai/showmeyourskin/compat/wildfire_gender/mixin/BreastPhysicsMixin.java
@@ -1,0 +1,34 @@
+package nl.enjarai.showmeyourskin.compat.wildfire_gender.mixin;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.sugar.Local;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.player.PlayerEntity;
+import nl.enjarai.showmeyourskin.config.HideableEquipment;
+import nl.enjarai.showmeyourskin.config.ModConfig;
+import org.spongepowered.asm.mixin.Dynamic;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Pseudo
+@Mixin(targets = "com.wildfire.physics.BreastPhysics")
+public abstract class BreastPhysicsMixin {
+    @Dynamic
+    @ModifyExpressionValue(
+            method = "update",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lcom/wildfire/main/entitydata/EntityConfig;getArmorPhysicsOverride()Z"
+            )
+    )
+    private boolean showmeyourskin$suppressArmorPhysicsResistance(boolean original, @Local(argsOnly = true) LivingEntity entity) {
+        if (entity instanceof PlayerEntity player) {
+            if (ModConfig.INSTANCE.getApplicablePieceTransparency(player.getUuid(), HideableEquipment.CHEST) <= 0) {
+                return true;
+            }
+        }
+
+        return original;
+    }
+}

--- a/src/main/java/nl/enjarai/showmeyourskin/compat/wildfire_gender/mixin/GenderLayerMixin.java
+++ b/src/main/java/nl/enjarai/showmeyourskin/compat/wildfire_gender/mixin/GenderLayerMixin.java
@@ -1,0 +1,35 @@
+package nl.enjarai.showmeyourskin.compat.wildfire_gender.mixin;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.sugar.Local;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemStack;
+import nl.enjarai.showmeyourskin.config.HideableEquipment;
+import nl.enjarai.showmeyourskin.config.ModConfig;
+import org.spongepowered.asm.mixin.Dynamic;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Pseudo
+@Mixin(targets = "com.wildfire.render.GenderLayer")
+public abstract class GenderLayerMixin {
+    @Dynamic
+    @ModifyExpressionValue(
+            method = "setupRender",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/entity/LivingEntity;getEquippedStack(Lnet/minecraft/entity/EquipmentSlot;)Lnet/minecraft/item/ItemStack;"
+            )
+    )
+    private ItemStack showmeyourskin$suppressArmorTransform(ItemStack original, @Local(argsOnly = true) LivingEntity entity) {
+        if (entity instanceof PlayerEntity player) {
+            if (ModConfig.INSTANCE.getApplicablePieceTransparency(player.getUuid(), HideableEquipment.CHEST) <= 0) {
+                return ItemStack.EMPTY;
+            }
+        }
+
+        return original;
+    }
+}

--- a/src/main/resources/showmeyourskin.compat.wildfire_gender.mixins.json
+++ b/src/main/resources/showmeyourskin.compat.wildfire_gender.mixins.json
@@ -7,7 +7,9 @@
   "mixins": [
   ],
   "client": [
-    "GenderArmorLayerMixin"
+    "BreastPhysicsMixin",
+    "GenderArmorLayerMixin",
+    "GenderLayerMixin"
   ],
   "injectors": {
     "defaultRequire": 0


### PR DESCRIPTION
Fixes #63

These changes only apply to 1.20.2 and newer (specifically [1.20.2-3.2](https://modrinth.com/mod/female-gender/version/1.20.2-3.2)); 1.20.1 and older versions are unaffected by the changes which broke this compatibility hook in the first place.

While there isn't an official release for 1.20.3/.4 on Modrinth or Curseforge, this has been tested against https://github.com/WildfireRomeo/WildfireFemaleGenderMod/commit/b3cace431b3ffb4e33b54362d213fec434bae294.
