### PR TITLE
Force enable elytra when the player entity is using it to fly

### DIFF
--- a/src/main/java/nl/enjarai/showmeyourskin/mixin/elytra/ElytraFeatureRendererMixin.java
+++ b/src/main/java/nl/enjarai/showmeyourskin/mixin/elytra/ElytraFeatureRendererMixin.java
@@ -38,9 +38,10 @@ public abstract class ElytraFeatureRendererMixin<T extends LivingEntity, M exten
             MatrixStack matrixStack, VertexConsumerProvider vertexConsumerProvider, int i, T livingEntity, float f,
             float g, float h, float j, float k, float l, CallbackInfo ci) {
         if (livingEntity instanceof PlayerEntity player) {
-            if (ModConfig.INSTANCE.getApplicablePieceTransparency(player.getUuid(), HideableEquipment.ELYTRA) <= 0) {
-                ci.cancel();
-            }
+            if (
+                    !player.isFallFlying() &&
+                    ModConfig.INSTANCE.getApplicablePieceTransparency(player.getUuid(), HideableEquipment.ELYTRA) <= 0
+            ) ci.cancel();
         }
     }
 
@@ -54,7 +55,9 @@ public abstract class ElytraFeatureRendererMixin<T extends LivingEntity, M exten
     )
     private boolean showmeyourskin$hideElytraGlint(boolean original, @Local(argsOnly = true) LivingEntity entity) {
         if (entity instanceof PlayerEntity player) {
-            return original && ModConfig.INSTANCE.getApplicableGlintTransparency(player.getUuid(), HideableEquipment.ELYTRA) > 0;
+            if (!player.isFallFlying()) {
+                return original && ModConfig.INSTANCE.getApplicableGlintTransparency(player.getUuid(), HideableEquipment.ELYTRA) > 0;
+            }
         }
 
         return original;
@@ -71,9 +74,11 @@ public abstract class ElytraFeatureRendererMixin<T extends LivingEntity, M exten
             VertexConsumerProvider vertexConsumerProvider, RenderLayer renderLayer, boolean solid, boolean hasGlint,
             Operation<VertexConsumer> original, @Local(argsOnly = true) LivingEntity entity) {
         if (entity instanceof PlayerEntity player) {
-            var transparency = ModConfig.INSTANCE.getApplicablePieceTransparency(player.getUuid(), HideableEquipment.ELYTRA);
-            if (transparency < 1) {
-                return ItemRenderer.getDirectItemGlintConsumer(vertexConsumerProvider, renderLayer, solid, hasGlint);
+            if (!player.isFallFlying()) {
+                var transparency = ModConfig.INSTANCE.getApplicablePieceTransparency(player.getUuid(), HideableEquipment.ELYTRA);
+                if (transparency < 1) {
+                    return ItemRenderer.getDirectItemGlintConsumer(vertexConsumerProvider, renderLayer, solid, hasGlint);
+                }
             }
         }
 
@@ -90,9 +95,11 @@ public abstract class ElytraFeatureRendererMixin<T extends LivingEntity, M exten
     private RenderLayer showmeyourskin$enableElytraTransparency2(
             Identifier texture, Operation<RenderLayer> original, @Local(argsOnly = true) LivingEntity entity) {
         if (entity instanceof PlayerEntity player) {
-            var transparency = ModConfig.INSTANCE.getApplicablePieceTransparency(player.getUuid(), HideableEquipment.ELYTRA);
-            if (transparency < 1) {
-                return RenderLayer.getEntityTranslucent(texture);
+            if (!player.isFallFlying()) {
+                var transparency = ModConfig.INSTANCE.getApplicablePieceTransparency(player.getUuid(), HideableEquipment.ELYTRA);
+                if (transparency < 1) {
+                    return RenderLayer.getEntityTranslucent(texture);
+                }
             }
         }
 
@@ -109,9 +116,11 @@ public abstract class ElytraFeatureRendererMixin<T extends LivingEntity, M exten
     )
     private float showmeyourskin$applyElytraTransparency(float original, @Local(argsOnly = true) LivingEntity entity) {
         if (entity instanceof PlayerEntity player) {
-            var transparency = ModConfig.INSTANCE.getApplicablePieceTransparency(player.getUuid(), HideableEquipment.ELYTRA);
-            if (transparency < 1) {
-                return transparency;
+            if (!player.isFallFlying()) {
+                var transparency = ModConfig.INSTANCE.getApplicablePieceTransparency(player.getUuid(), HideableEquipment.ELYTRA);
+                if (transparency < 1) {
+                    return transparency;
+                }
             }
         }
 


### PR DESCRIPTION
I felt like the elytra should be forced-on when the player is flying, because it looked a bit weird when the elytra was disabled. I guess this could be made into an option but I don't know much about how to do that so I left it here