### PR TITLE
Use latest Fabric API for 1.21.1 support

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,24 +3,24 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-deps.minecraft=1.21
-deps.yarn=1.21+build.2
+deps.minecraft=1.21.1
+deps.yarn=1.21.1+build.1
 deps.fabricloader=0.15.11
 
 # Mod Properties
-mod_version = 1.11.2
+mod_version = 1.11.3
 maven_group = nl.enjarai
 archives_base_name = show-me-your-skin
 
 publish_target_min=1.21
-publish_target_max=1.21
+publish_target_max=1.21.1
 mod_modrinth=bD7YqcA3
 mod_curseforge=622010
 mod_github=enjarai/show-me-your-skin
 git_branch=master
 
 # Dependencies
-deps.fabric-api=0.100.3+1.21
+deps.fabric-api=0.102.0+1.21.1
 # https://modrinth.com/mod/modmenu/versions
 deps.modmenu=11.0.1
 deps.cicada=0.8.0+1.21-and-above

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,8 +3,8 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-deps.minecraft=1.21.1
-deps.yarn=1.21.1+build.1
+deps.minecraft=1.21
+deps.yarn=1.21+build.9
 deps.fabricloader=0.15.11
 
 # Mod Properties
@@ -20,7 +20,7 @@ mod_github=enjarai/show-me-your-skin
 git_branch=master
 
 # Dependencies
-deps.fabric-api=0.102.0+1.21.1
+deps.fabric-api=0.102.0+1.21
 # https://modrinth.com/mod/modmenu/versions
 deps.modmenu=11.0.1
 deps.cicada=0.8.0+1.21-and-above

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -45,7 +45,7 @@
   "depends": {
     "fabricloader": ">=0.15.0",
     "fabric-api": "*",
-    "minecraft": ">=1.21.0- <=1.21.0",
+    "minecraft": ">=1.21.0- <=1.21.1",
     "cicada": ">=0.7.0 <1.0.0",
     "cardinal-components-base": "*",
     "cardinal-components-entity": "*"


### PR DESCRIPTION
- Update mod compatibility to support 1.21.1

Notes:
- Mod works as intended with an end-user Fabric 1.21.1 client
- Should work with other supported mods, but will be tested further once their respective versions have been rolled out 