### PR TITLE
Revamp CI workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,37 +3,56 @@
 # certain platforms or Java versions, and provides a first line of defence
 # against bad commits.
 
-name: build
+name: Build & Upload
 on: [pull_request, push]
+
+env:
+  MOD_VERSION: 'latest' # fallback for version flex
+  MINECRAFT_VERSION: ''
 
 jobs:
   build:
     strategy:
       matrix:
-        # Use these Java versions
-        java: [
-            21,    # Current Java LTS & minimum supported by Minecraft
-        ]
-        # and run on both Linux and Windows
-        os: [ubuntu-20.04, windows-2022]
+        java: [ 21 ]
+        java-distribution: ['corretto']
+        os: [ubuntu-latest, windows-latest]
+        include:
+        - os: ubuntu-latest
+          upload-artifacts: true
+        - os: windows-latest
+          upload-artifacts: false
     runs-on: ${{ matrix.os }}
     steps:
-      - name: checkout repository
-        uses: actions/checkout@v2
-      - name: validate gradle wrapper
-        uses: gradle/wrapper-validation-action@v1
-      - name: setup jdk ${{ matrix.java }}
-        uses: actions/setup-java@v1
+      - uses: actions/checkout@v4
+
+      - name: Retrieve Mod/MC Version # just a little flex
+        if: contains(matrix.os, 'ubuntu') && matrix.upload-artifacts
+        run: |
+          mod_version=$(grep '^mod_version' gradle.properties | awk -F ' = ' '{print $2}')
+          minecraft_version=$(grep '^deps.minecraft' gradle.properties | awk -F '=' '{print $2}')
+          echo "MOD_VERSION=$mod_version" >> $GITHUB_ENV
+          echo "MINECRAFT_VERSION=$minecraft_version" >> $GITHUB_ENV
+          
+      - name: Validate Gradle Wrapper
+        uses: gradle/actions/wrapper-validation@v3
+        
+      - name: Setup JDK ${{ matrix.java }}
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
-      - name: make gradle wrapper executable
-        if: ${{ runner.os != 'Windows' }}
-        run: chmod +x ./gradlew
-      - name: build
+          distribution: ${{ matrix.java-distribution }}
+          
+      - name: chmod Gradle Wrapper
+        if: contains(matrix.os, 'ubuntu')
+        run: chmod +x gradlew
+        
+      - name: Build
         run: ./gradlew build
-      - name: capture build artifacts
-        if: ${{ runner.os == 'Linux' && matrix.java == '17' }} # Only upload artifacts built from latest java on one OS
-        uses: actions/upload-artifact@v2
+        
+      - name: Upload Artifacts
+        if: matrix.upload-artifacts
+        uses: actions/upload-artifact@v4
         with:
-          name: Artifacts
+          name: show-me-your-skin_${{ env.MOD_VERSION }}+${{ env.MINECRAFT_VERSION }}
           path: build/libs/


### PR DESCRIPTION
A little workflow revamp:
- Updated actions
- Simplified and prettified workflow
- Added a little flex with versions to add them to artifact name

I also removed check for uploading single artifact only. I noticed you had check for java 17 when using java 21, so I guess you don't care much and don't update them. So better not check for any and just leave matrix java in single instance